### PR TITLE
Fix GHC 8.0.2 build

### DIFF
--- a/Geography/VectorTile/Geometry.hs
+++ b/Geography/VectorTile/Geometry.hs
@@ -40,7 +40,7 @@ pattern Point :: Int -> Int -> (Int, Int)
 pattern Point{x, y} = (x, y)
 
 -- | Points are just vectors in R2, and thus form a Vector space.
-instance Monoid Point where
+instance {-# OVERLAPPING #-} Monoid Point where
   mempty = Point 0 0
   (Point a b) `mappend` (Point a' b') = Point (a + a') (b + b')
 


### PR DESCRIPTION
This library fails to build with GHC 8.0.2 because it mistakenly doesn't annotate the overlapping `Monoid Point` instance with an `OVERLAPPING` annotation (8.0.2 is more strict about this than previous versions, see https://ghc.haskell.org/trac/ghc/ticket/12881). Luckily, it's easy to fix.