### PR TITLE
Further improve performance

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,5 +1,3 @@
--- -*- dante-target: "vectortiles-bench"; -*-
-
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -7,7 +5,7 @@ module Main where
 import           Criterion.Main
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict as M
 import           Geography.VectorTile
 import           Lens.Micro
 import           Lens.Micro.Platform ()  -- Instances only.
@@ -25,23 +23,23 @@ main = do
       pl' = fromRight $ tile pl
       rd' = fromRight $ tile rd
   defaultMain [ bgroup "Decoding"
-                [ bgroup "onepoint.mvt" $ decodes op
+                [ bgroup "onepoint.mvt"   $ decodes op
                 , bgroup "linestring.mvt" $ decodes ls
-                , bgroup "polygon.mvt" $ decodes pl
-                , bgroup "roads.mvt" $ decodes rd
+                , bgroup "polygon.mvt"    $ decodes pl
+                , bgroup "roads.mvt"      $ decodes rd
                 ]
               , bgroup "Encoding"
-                [ bgroup "Point" $ encodes op'
+                [ bgroup "Point"      $ encodes op'
                 , bgroup "LineString" $ encodes ls'
-                , bgroup "Polygon" $ encodes pl'
-                , bgroup "Roads" $ encodes rd'
+                , bgroup "Polygon"    $ encodes pl'
+                , bgroup "Roads"      $ encodes rd'
                 ]
               , bgroup "Data Access"
                 [ bgroup "All Layer Names"
-                  [ bench "One Point" $ nf layerNames op
+                  [ bench "One Point"      $ nf layerNames op
                   , bench "One LineString" $ nf layerNames ls
-                  , bench "One Polygon" $ nf layerNames pl
-                  , bench "roads.mvt" $ nf layerNames rd
+                  , bench "One Polygon"    $ nf layerNames pl
+                  , bench "roads.mvt"      $ nf layerNames rd
                   ]
                 , bgroup "First Polygon"
                   [ bench "One Polygon" $ nf (firstPoly "OnePolygon") op

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -7,7 +7,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as M
 import           Data.Monoid ((<>))
-import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import           Geography.VectorTile
 import           Lens.Micro
 import           Lens.Micro.Platform ()  -- Instances only.
@@ -71,9 +71,9 @@ fromRight :: Either a b -> b
 fromRight (Right b) = b
 fromRight _ = error "`Left` given to fromRight!"
 
-tinyvec :: V.Vector Point
-tinyvec = V.fromList [ Point 1 1, Point 2 1, Point 2 2, Point 1 2, Point 1 1 ]
+tinyvec :: VS.Vector Point
+tinyvec = VS.fromList [ Point 1 1, Point 2 1, Point 2 2, Point 1 2, Point 1 1 ]
 
-bigvec :: V.Vector Point
-bigvec = ps <> V.fromList [ Point 500 1000, Point 1 1 ]
-  where ps = V.fromList $ map (\n -> Point n 1) [ 1 .. 1000 ]
+bigvec :: VS.Vector Point
+bigvec = ps <> VS.fromList [ Point 500 1000, Point 1 1 ]
+  where ps = VS.fromList $ map (\n -> Point n 1) [ 1 .. 1000 ]

--- a/lib/Geography/VectorTile.hs
+++ b/lib/Geography/VectorTile.hs
@@ -47,7 +47,7 @@ module Geography.VectorTile
   , geometries
   , Val(..)
   -- * Geometries
-  , Point, x, y
+  , Point(..)
   , LineString(..)
   , Polygon(..)
   , area

--- a/lib/Geography/VectorTile/Geometry.hs
+++ b/lib/Geography/VectorTile/Geometry.hs
@@ -67,7 +67,7 @@ area p = surveyor (polyPoints p) + foldl' (\acc i -> acc + area i) 0 (inner p)
 -- If the value reported here is negative, then the `Polygon` should be
 -- considered an Interior Ring.
 --
--- Assumption: The `U.Vector` given has at least 4 `Point`s.
+-- Assumption: The `V.Vector` given has at least 4 `Point`s.
 surveyor :: V.Vector Point -> Double
 surveyor v = (/ 2) . fromIntegral . V.foldl' (+) 0 $ V.zipWith3 (\xn yn yp -> xn * (yn - yp)) xs yns yps
   where v' = V.init v

--- a/lib/Geography/VectorTile/Internal.hs
+++ b/lib/Geography/VectorTile/Internal.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE BangPatterns, ViewPatterns #-}
 
 -- |
 -- Module    : Geography.VectorTile.Internal
@@ -114,9 +111,9 @@ instance Protobuffable VT.Layer where
     Feats ps ls polys <- feats (utf8 <$> Layer.keys l) (Layer.values l) $ Layer.features l
     pure VT.Layer { VT._version = fromIntegral $ Layer.version l
                   , VT._name = utf8 $ Layer.name l
-                  , VT._points = VB.build ps
-                  , VT._linestrings = VB.build ls
-                  , VT._polygons = VB.build polys
+                  , VT._points = ps
+                  , VT._linestrings = ls
+                  , VT._polygons = polys
                   , VT._extent = maybe 4096 fromIntegral (Layer.extent l) }
 
   toProtobuf l = Layer.Layer { Layer.version   = fromIntegral $ VT._version l
@@ -302,21 +299,31 @@ uncommands = Seq.fromList >=> f
 -- is not possible.
 feats :: Seq BL.ByteString -> Seq Value.Value -> Seq Feature.Feature -> Either Text Feats
 feats _ _ Seq.Empty = Left "VectorTile.features: `[RawFeature]` empty"
-feats keys vals fs = foldlM g (Feats mempty mempty mempty) fs
+feats keys vals (toList -> fs) = do
+  pnts <- V.fromList <$> h GeomType.POINT
+  lins <- V.fromList <$> h GeomType.LINESTRING
+  plys <- V.fromList <$> h GeomType.POLYGON
+  -- foldlM g (Feats mempty mempty mempty) fs
+  pure $ Feats pnts lins plys
   where f :: ProtobufGeom g => Feature.Feature -> Either Text (VT.Feature (GeomVec g))
         f x = VT.Feature
           <$> pure (maybe 0 fromIntegral $ Feature.id x)
           <*> getMeta keys vals (Feature.tags x)
           <*> (fromCommands . commands . toList $ Feature.geometry x)
-        g !feets@(Feats ps ls po) fe = case Feature.type' fe of
-          Just GeomType.POINT      -> (\fe' -> feets { featPoints = ps <> VB.singleton fe' }) <$> f fe
-          Just GeomType.LINESTRING -> (\fe' -> feets { featLines  = ls <> VB.singleton fe' }) <$> f fe
-          Just GeomType.POLYGON    -> (\fe' -> feets { featPolys  = po <> VB.singleton fe' }) <$> f fe
-          _ -> Left "Geometry type of UNKNOWN given."
 
-data Feats = Feats { featPoints :: !(VB.Builder (VT.Feature (GeomVec G.Point)))
-                   , featLines  :: !(VB.Builder (VT.Feature (GeomVec G.LineString)))
-                   , featPolys  :: !(VB.Builder (VT.Feature (GeomVec G.Polygon))) }
+        -- g feets@(Feats ps ls po) fe = case Feature.type' fe of
+        --   Just GeomType.POINT      -> (\fe' -> feets { featPoints = ps <> VB.singleton fe' }) <$> f fe
+        --   Just GeomType.LINESTRING -> (\fe' -> feets { featLines  = ls <> VB.singleton fe' }) <$> f fe
+        --   Just GeomType.POLYGON    -> (\fe' -> feets { featPolys  = po <> VB.singleton fe' }) <$> f fe
+        --   _ -> Left "Geometry type of UNKNOWN given."
+
+        h :: ProtobufGeom g => GeomType.GeomType -> Either Text [VT.Feature (GeomVec g)]
+        h gt = traverse f $ filter (\fe -> Feature.type' fe == Just gt) fs
+
+
+data Feats = Feats { featPoints :: !(V.Vector (VT.Feature (GeomVec G.Point)))
+                   , featLines  :: !(V.Vector (VT.Feature (GeomVec G.LineString)))
+                   , featPolys  :: !(V.Vector (VT.Feature (GeomVec G.Polygon))) }
 
 getMeta :: Seq BL.ByteString -> Seq Value.Value -> Seq Word32 -> Either Text (M.HashMap BL.ByteString VT.Val)
 getMeta keys vals tags = do

--- a/lib/Geography/VectorTile/Internal.hs
+++ b/lib/Geography/VectorTile/Internal.hs
@@ -55,7 +55,7 @@ import           Control.Monad.Trans.State.Strict
 import           Data.Bits
 import qualified Data.ByteString.Lazy as BL
 import           Data.Foldable (fold, foldl', foldlM, toList)
-import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as HS
 import           Data.Int
 import           Data.Maybe (fromJust)
@@ -238,8 +238,8 @@ parseCmd n = case cmd of
         count = shift n (-3)
 
 -- | Recombine a Command ID and parameter count into a Command Integer.
-unparseCmd :: (Int,Int) -> Word32
-unparseCmd (cmd,count) = fromIntegral $ (cmd .&. 7) .|. shift count 3
+unparseCmd :: Pair -> Word32
+unparseCmd (Pair cmd count) = fromIntegral $ (cmd .&. 7) .|. shift count 3
 {-# INLINE unparseCmd #-}
 
 -- | Attempt to parse a list of Command/Parameter integers, as defined here:
@@ -265,9 +265,9 @@ commands = go (Right Seq.Empty)
 -- and Z-encoded Parameter integer forms.
 uncommands :: Seq Command -> Seq Word32
 uncommands = (>>= f)
-  where f (MoveTo ps) = unparseCmd (1, length ps) <| params ps
-        f (LineTo ls) = unparseCmd (2, length ls) <| params ls
-        f ClosePath   = Seq.singleton $ unparseCmd (7,1)  -- ClosePath, Count 1.
+  where f (MoveTo ps) = unparseCmd (Pair 1 (length ps)) <| params ps
+        f (LineTo ls) = unparseCmd (Pair 2 (length ls)) <| params ls
+        f ClosePath   = Seq.singleton $ unparseCmd (Pair 7 1)  -- ClosePath, Count 1.
 
 {- FROM PROTOBUF -}
 

--- a/lib/Geography/VectorTile/Internal.hs
+++ b/lib/Geography/VectorTile/Internal.hs
@@ -61,7 +61,7 @@ import qualified Data.HashSet as HS
 import           Data.Int
 import           Data.List (unfoldr)
 import           Data.Maybe (fromJust)
-import           Data.Monoid
+import           Data.Semigroup hiding (diff)
 import           Data.Sequence (Seq, (<|), (|>), Seq())
 import qualified Data.Sequence as Seq
 import           Data.Text (Text, pack)
@@ -149,7 +149,7 @@ instance Protobuffable VT.Val where
 -- to convert between an encodable list of `Command`s.
 class ProtobufGeom g where
   fromCommands :: [Command] -> Either Text (V.Vector g)
-  toCommands :: V.Vector g -> [Command]
+  toCommands   :: V.Vector g -> [Command]
 
 -- | A valid `RawFeature` of points must contain a single `MoveTo` command
 -- with a count greater than 0.
@@ -353,7 +353,7 @@ params = VS.foldl' (\acc (G.Point a b) -> acc |> zig a |> zig b) Seq.Empty
 
 -- | Expand a pair of diffs from some reference point into that of a `Point` value.
 expand :: G.Point -> VS.Vector G.Point -> VS.Vector G.Point
-expand = VS.postscanl' (\(G.Point x y) (G.Point dx dy) -> G.Point (x + dx) (y + dy))
+expand = VS.postscanl' (<>)
 
 -- | Collapse a given `Point` into a pair of diffs, relative to
 -- the previous point in the sequence. The reference point is moved

--- a/lib/Geography/VectorTile/Util.hs
+++ b/lib/Geography/VectorTile/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, BangPatterns #-}
 
 -- |
 -- Module    : Geography.VectorTile.Util
@@ -10,18 +10,22 @@ module Geography.VectorTile.Util where
 
 import Data.Sequence (Seq, (|>), Seq(Empty, (:<|)))
 import Data.Text (Text)
+import Geography.VectorTile.Geometry (Point(..))
 
 ---
 
+-- | A strict pair of Ints.
+data Pair = Pair !Int !Int
+
 -- | A sort of "self-zip", forming pairs from every two elements in a list.
 -- Fails if there is an uneven number of elements.
-pairsWith :: (a -> b) -> Seq a -> Either Text (Seq (b, b))
+pairsWith :: (a -> Int) -> Seq a -> Either Text (Seq Point)
 pairsWith _ Empty = Right Empty
 pairsWith f s | odd $ length s = Left "Uneven number of parameters given."
               | otherwise = Right $ go Empty s
-  where go acc Empty = acc
-        go acc (x :<| y :<| zs) = go (acc |> (f x, f y)) zs
-        go acc (_ :<| Empty) = acc
+  where go !acc Empty = acc
+        go !acc (a :<| b :<| cs) = go (acc |> Point (f a) (f b)) cs
+        go !acc (_ :<| Empty) = acc
 
 -- | Flatten a list of pairs. Equivalent to:
 --

--- a/lib/Geography/VectorTile/Util.hs
+++ b/lib/Geography/VectorTile/Util.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings, BangPatterns #-}
-
 -- |
 -- Module    : Geography.VectorTile.Util
 -- Copyright : (c) Colin Woodbury 2016 - 2018

--- a/lib/Geography/VectorTile/Util.hs
+++ b/lib/Geography/VectorTile/Util.hs
@@ -8,9 +8,8 @@
 
 module Geography.VectorTile.Util where
 
-import Data.Sequence (Seq, (|>), Seq(Empty, (:<|)))
-import Data.Text (Text)
-import Geography.VectorTile.Geometry (Point(..))
+import qualified Data.Vector.Storable as VS
+import           Geography.VectorTile.Geometry (Point(..))
 
 ---
 
@@ -19,13 +18,19 @@ data Pair = Pair !Int !Int
 
 -- | A sort of "self-zip", forming pairs from every two elements in a list.
 -- Fails if there is an uneven number of elements.
-pairsWith :: (a -> Int) -> Seq a -> Either Text (Seq Point)
-pairsWith _ Empty = Right Empty
-pairsWith f s | odd $ length s = Left "Uneven number of parameters given."
-              | otherwise = Right $ go Empty s
-  where go !acc Empty = acc
-        go !acc (a :<| b :<| cs) = go (acc |> Point (f a) (f b)) cs
-        go !acc (_ :<| Empty) = acc
+-- pairsWith :: (a -> Int) -> [a] -> Either Text [Point]
+-- pairsWith _ [] = Right []
+-- pairsWith f s | odd $ length s = Left "Uneven number of parameters given."
+--               | otherwise = Right $ go Empty s
+--   where go !acc Empty = acc
+--         go !acc (a :<| b :<| cs) = go (acc |> Point (f a) (f b)) cs
+--         go !acc (_ :<| Empty) = acc
+
+pairsWith :: (a -> Int) -> [a] -> VS.Vector Point
+pairsWith f = VS.unfoldr g
+  where g []  = Nothing
+        g [_] = Nothing
+        g (a:b:cs) = Just (Point (f a) (f b), cs)
 
 -- | Flatten a list of pairs. Equivalent to:
 --

--- a/lib/Geography/VectorTile/VectorTile.hs
+++ b/lib/Geography/VectorTile/VectorTile.hs
@@ -37,10 +37,10 @@ module Geography.VectorTile.VectorTile
 
 import           Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashMap.Lazy as M
 import           Data.Hashable (Hashable)
 import           Data.Int
-import qualified Data.HashMap.Lazy as M
-import qualified Data.Sequence as Seq
+import qualified Data.Vector as V
 import           Data.Word
 import           GHC.Generics (Generic)
 import           Geography.VectorTile.Geometry
@@ -70,11 +70,11 @@ instance NFData VectorTile
 -- them here explicitely to allow for more fine-grained access to each type.
 data Layer = Layer { _version     :: Word  -- ^ The version of the spec we follow. Should always be 2.
                    , _name        :: BL.ByteString
-                   , _points      :: Seq.Seq (Feature Point)
-                   , _linestrings :: Seq.Seq (Feature LineString)
-                   , _polygons    :: Seq.Seq (Feature Polygon)
+                   , _points      :: V.Vector (Feature Point)
+                   , _linestrings :: V.Vector (Feature LineString)
+                   , _polygons    :: V.Vector (Feature Polygon)
                    , _extent      :: Word  -- ^ Default: 4096
-                   } deriving (Eq,Show,Generic)
+                   } deriving (Eq, Show, Generic)
 
 version :: Lens' Layer Word
 version f l = (\v -> l { _version = v }) <$> f (_version l)
@@ -84,15 +84,15 @@ name :: Lens' Layer BL.ByteString
 name f l = (\v -> l { _name = v }) <$> f (_name l)
 {-# INLINE name #-}
 
-points :: Lens' Layer (Seq.Seq (Feature Point))
+points :: Lens' Layer (V.Vector (Feature Point))
 points f l = (\v -> l { _points = v }) <$> f (_points l)
 {-# INLINE points #-}
 
-linestrings :: Lens' Layer (Seq.Seq (Feature LineString))
+linestrings :: Lens' Layer (V.Vector (Feature LineString))
 linestrings f l = (\v -> l { _linestrings = v }) <$> f (_linestrings l)
 {-# INLINE linestrings #-}
 
-polygons :: Lens' Layer (Seq.Seq (Feature Polygon))
+polygons :: Lens' Layer (V.Vector (Feature Polygon))
 polygons f l = (\v -> l { _polygons = v }) <$> f (_polygons l)
 {-# INLINE polygons #-}
 
@@ -118,9 +118,9 @@ instance NFData Layer
 --
 -- Note: The keys to the metadata are `BL.ByteString`, but are guaranteed
 -- to be UTF-8.
-data Feature g = Feature { _featureId :: Word  -- ^ Default: 0
-                         , _metadata :: M.HashMap BL.ByteString Val
-                         , _geometries :: Seq.Seq g } deriving (Eq,Show,Generic)
+data Feature g = Feature { _featureId  :: Word  -- ^ Default: 0
+                         , _metadata   :: M.HashMap BL.ByteString Val
+                         , _geometries :: V.Vector g } deriving (Eq, Show, Generic)
 
 featureId :: Lens' (Feature g) Word
 featureId f l = (\v -> l { _featureId = v }) <$> f (_featureId l)
@@ -130,7 +130,7 @@ metadata :: Lens' (Feature g) (M.HashMap BL.ByteString Val)
 metadata f l = (\v -> l { _metadata = v }) <$> f (_metadata l)
 {-# INLINE metadata #-}
 
-geometries :: Lens' (Feature g) (Seq.Seq g)
+geometries :: Lens' (Feature g) (V.Vector g)
 geometries f l = (\v -> l { _geometries = v }) <$> f (_geometries l)
 {-# INLINE geometries #-}
 

--- a/package.yaml
+++ b/package.yaml
@@ -54,7 +54,6 @@ library:
   dependencies:
     - deepseq >=1.4 && <1.5
     - transformers >=0.5 && <0.6
-    - vector-builder >= 0.3 && < 0.4
 
 tests:
   vectortiles-test:

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ library:
   dependencies:
     - deepseq >=1.4 && <1.5
     - transformers >=0.5 && <0.6
+    - vector-builder >= 0.3 && < 0.4
 
 tests:
   vectortiles-test:

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ dependencies:
   - bytestring
   - containers
   - hashable
+  - mtl
   - protocol-buffers >= 2.4 && < 2.5
   - protocol-buffers-descriptor >= 2.4 && < 2.5
   - text >=1.2 && <1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.1
+resolver: lts-11.2
 
 packages:
   - .

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -6,16 +6,17 @@ module Main where
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import           Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
-import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import           Geography.VectorTile
 import qualified Geography.VectorTile.Internal as I
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Text.ProtocolBuffers.Basic (Utf8(..), defaultValue)
-import           Text.ProtocolBuffers.WireMessage (Wire, messageGet)
 import           Text.ProtocolBuffers.Reflections (ReflectDescriptor)
+import           Text.ProtocolBuffers.WireMessage (Wire, messageGet)
 
 ---
 
@@ -51,16 +52,17 @@ suite op ls pl rd cl = testGroup "Unit Tests"
   , testGroup "Geometries"
     [ testCase "area" $ area poly @?= 1
     , testCase "surveyor - outer" . assertBool "surveyor outer" $ surveyor (polyPoints poly) > 0
-    , testCase "surveyor - inner" . assertBool "surveyor inner" $ surveyor (V.reverse $ polyPoints poly) < 0
+    , testCase "surveyor - inner" . assertBool "surveyor inner" $ surveyor (VS.reverse $ polyPoints poly) < 0
     , testCase "Z-encoding Isomorphism" zencoding
     , testCase "Command Parsing" commandTest
-    , testCase "Polygon Validity" $ V.head (polyPoints poly) @?= V.last (polyPoints poly)
+    , testCase "Polygon Validity" $ VS.head (polyPoints poly) @?= VS.last (polyPoints poly)
     , testCase "[Word32] <-> [Command]" commandIso
     , testCase "[Word32] <-> V.Vector Point" pointIso
     , testCase "[Word32] <-> V.Vector LineString" linestringIso
     , testCase "[Word32] <-> V.Vector Polygon (2 solid)" polygonIso
     , testCase "[Word32] <-> V.Vector Polygon (1 holed)" polygonIso2
     , testCase "[Word32] <-> V.Vector Polygon (1 holed, 1 solid)" polygonIso3
+    , testCase "Point Storable Instance" $ VS.toList (VS.fromList [Point 1 2, Point 3 4]) @?= [Point 1 2, Point 3 4]
     ]
   ]
 
@@ -157,45 +159,45 @@ zencoding = map (I.unzig . I.zig) vs @?= vs
   where vs = [0,(-1),1,(-2),2,(-3),3,2147483647,(-2147483648)]
 
 commandTest :: Assertion
-commandTest = I.commands (Seq.fromList [9,4,4,18,6,4,5,4,15]) @?= Right (
-  Seq.fromList [ I.MoveTo $ Seq.singleton (Point 2 2)
-               , I.LineTo $ Seq.fromList [ Point 3 2, Point (-3) 2 ]
-               , I.ClosePath ]
-  )
+commandTest = I.commands [9,4,4,18,6,4,5,4,15]
+  @?= [ I.MoveTo $ VS.singleton (Point 2 2)
+      , I.LineTo $ VS.fromList [ Point 3 2, Point (-3) 2 ]
+      , I.ClosePath ]
 
 commandIso :: Assertion
-commandIso = (I.uncommands . fromRight $ I.commands cs) @?= cs
-  where cs = Seq.fromList [9,4,4,18,6,4,5,4,15]
+commandIso = (I.uncommands $ I.commands cs) @?= Seq.fromList cs
+  where cs = [9,4,4,18,6,4,5,4,15]
 
 pointIso :: Assertion
 pointIso = cs' @?= cs
-  where cs = Seq.fromList [25,4,4,6,6,3,3]
-        cs' = fromRight $ I.uncommands . I.toCommands <$> (I.commands cs >>= I.fromCommands @Point)
+  where cs = [25,4,4,6,6,3,3]
+        cs' = toList . fromRight $ I.uncommands . I.toCommands <$> (I.fromCommands @Point $ I.commands cs)
 
 linestringIso :: Assertion
 linestringIso = cs' @?= cs
-  where cs = Seq.fromList [9,4,4,18,6,4,5,4,9,4,4,18,6,4,5,4]
-        cs' = fromRight $ I.uncommands . I.toCommands <$> (I.commands cs >>= I.fromCommands @LineString)
+  where cs = [9,4,4,18,6,4,5,4,9,4,4,18,6,4,5,4]
+        cs' = toList . fromRight $ I.uncommands . I.toCommands <$> (I.fromCommands @LineString $ I.commands cs)
 
 -- | Two solids
 polygonIso :: Assertion
 polygonIso = cs' @?= cs
-  where cs = Seq.fromList [9,4,4,18,6,4,5,4,15,9,4,4,18,6,4,5,4,15]
-        cs' = fromRight $ I.uncommands . I.toCommands <$> (I.commands cs >>= I.fromCommands @Polygon)
+  where cs = [9,4,4,18,6,4,5,4,15,9,4,4,18,6,4,5,4,15]
+        cs' = toList . fromRight $ I.uncommands . I.toCommands <$> (I.fromCommands @Polygon $ I.commands cs)
 
 -- | One holed
 polygonIso2 :: Assertion
 polygonIso2 = cs' @?= cs
-  where cs = Seq.fromList [9,4,4,26,6,0,0,6,5,0,15,9,2,3,26,0,2,2,0,0,1,15]
-        cs' = fromRight $ I.uncommands . I.toCommands <$> (I.commands cs >>= I.fromCommands @Polygon)
+  where cs = [9,4,4,26,6,0,0,6,5,0,15,9,2,3,26,0,2,2,0,0,1,15]
+        cs' = toList . fromRight $ I.uncommands . I.toCommands <$> (I.fromCommands @Polygon $ I.commands cs)
 
 -- | One Holed, one solid
 polygonIso3 :: Assertion
 polygonIso3 = cs' @?= cs
-  where cs = Seq.fromList [ 9, 4, 4, 26, 6, 0, 0, 6, 5, 0, 15, 9, 2, 3, 26, 0, 2, 2, 0, 0, 1, 15
+  where cs = [ 9, 4, 4, 26, 6, 0, 0, 6, 5, 0, 15
+             , 9, 2, 3, 26, 0, 2, 2, 0, 0, 1, 15
              , 9, 4, 4, 26, 6, 0, 0, 6, 5, 0, 15 ]
-        cs' = fromRight $ I.uncommands . I.toCommands <$> (I.commands cs >>= I.fromCommands @Polygon)
+        cs' = toList . fromRight . fmap (I.uncommands . I.toCommands) . I.fromCommands @Polygon $ I.commands cs
 
 poly :: Polygon
 poly = Polygon ps mempty
-  where ps = V.fromList [(Point 0 0), (Point 1 0), (Point 1 1), (Point 0 1), (Point 0 0)]
+  where ps = VS.fromList [(Point 0 0), (Point 1 0), (Point 1 1), (Point 0 1), (Point 0 0)]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -54,6 +54,7 @@ suite op ls pl rd cl = testGroup "Unit Tests"
     , testCase "surveyor - inner" . assertBool "surveyor inner" $ surveyor (V.reverse $ polyPoints poly) < 0
     , testCase "Z-encoding Isomorphism" zencoding
     , testCase "Command Parsing" commandTest
+    , testCase "Polygon Validity" $ V.head (polyPoints poly) @?= V.last (polyPoints poly)
     , testCase "[Word32] <-> [Command]" commandIso
     , testCase "[Word32] <-> V.Vector Point" pointIso
     , testCase "[Word32] <-> V.Vector LineString" linestringIso

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Main where

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,5 +1,3 @@
--- -*- dante-target: "vectortiles-test"; -*-
-
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeApplications #-}
@@ -10,7 +8,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
-import qualified Data.Vector.Unboxed as U
+import qualified Data.Vector as V
 import           Geography.VectorTile
 import qualified Geography.VectorTile.Internal as I
 import           Test.Tasty
@@ -53,7 +51,7 @@ suite op ls pl rd cl = testGroup "Unit Tests"
   , testGroup "Geometries"
     [ testCase "area" $ area poly @?= 1
     , testCase "surveyor - outer" . assertBool "surveyor outer" $ surveyor (polyPoints poly) > 0
-    , testCase "surveyor - inner" . assertBool "surveyor inner" $ surveyor (U.reverse $ polyPoints poly) < 0
+    , testCase "surveyor - inner" . assertBool "surveyor inner" $ surveyor (V.reverse $ polyPoints poly) < 0
     , testCase "Z-encoding Isomorphism" zencoding
     , testCase "Command Parsing" commandTest
     , testCase "[Word32] <-> [Command]" commandIso
@@ -159,8 +157,8 @@ zencoding = map (I.unzig . I.zig) vs @?= vs
 
 commandTest :: Assertion
 commandTest = I.commands (Seq.fromList [9,4,4,18,6,4,5,4,15]) @?= Right (
-  Seq.fromList [ I.MoveTo $ Seq.singleton (2,2)
-               , I.LineTo $ Seq.fromList [(3,2),(-3,2)]
+  Seq.fromList [ I.MoveTo $ Seq.singleton (Point 2 2)
+               , I.LineTo $ Seq.fromList [ Point 3 2, Point (-3) 2 ]
                , I.ClosePath ]
   )
 
@@ -199,4 +197,4 @@ polygonIso3 = cs' @?= cs
 
 poly :: Polygon
 poly = Polygon ps mempty
-  where ps = U.fromList [(0,0), (1,0), (1,1), (0,1), (0,0)]
+  where ps = V.fromList [(Point 0 0), (Point 1 0), (Point 1 1), (Point 0 1), (Point 0 0)]


### PR DESCRIPTION
### Tuples

Turns out tuples are evil!

Replacing the old `Point` pattern synonym over a tuple with:
```haskell
data Point = Point { x :: !Int, y :: !Int }
```
we see a healthy speedup for both decoding and encoding.

### `Storable` Vectors

It was easy to write a `Storable` instance for `Point`. "Storable Vectors" are very performant, so I've moved back off of `Seq` and onto storable vectors where ever possible.

### Unfolding

To avoid manual consing, I use `unfoldr` and `unfoldrM` where ever possible. 